### PR TITLE
Improve docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ references.txt
 .coverage
 *.egg-info
 __pycache__
-instance
 *.sublime-project
 *.sublime-workspace
 venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN mkdir /var/lib/graphsense-rest && \
     pip3 install /srv/graphsense-rest/ && \
     chown -R dockeruser /usr/var/gsrest-instance
 
+#RUN mkdir /usr/var/data && chown -R dockeruser /usr/var/data
+#VOLUME ["/usr/var/data"]
 USER dockeruser
-RUN flask init-db
 
-CMD /usr/bin/gunicorn -c /home/dockeruser/gunicorn-conf.py -w $NUM_WORKERS "gsrest:create_app()"
+CMD flask init-db && /usr/bin/gunicorn -c /home/dockeruser/gunicorn-conf.py -w $NUM_WORKERS "gsrest:create_app()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN mkdir /var/lib/graphsense-rest && \
 #VOLUME ["/usr/var/data"]
 USER dockeruser
 
-CMD flask init-db && /usr/bin/gunicorn -c /home/dockeruser/gunicorn-conf.py -w $NUM_WORKERS "gsrest:create_app()"
+CMD /usr/bin/gunicorn -c /home/dockeruser/gunicorn-conf.py -w $NUM_WORKERS "gsrest:create_app()"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,46 @@ The GraphSense REST Interface provides access to denormalized views computed
 by the [graphsense-transformation][graphsense-transformation] pipeline.
 It is used by the [graphsense-dashboard][graphsense-dashboard] component.
 
+## Quick docker setup
+
+### Prerequisites
+Make sure the latest versions of Docker and docker-compose are installed. https://docs.docker.com/compose/install/
+
+This service assumes that:
+ - There is a cassandra instance running;
+ - Both parser and exporter from `graphsense-blocksci` have completed fetching data into that cassandra instance.
+ - The transformation pipeline has completed.
+ 
+**It is possible to set up all required services using a single docker-compose evironment. For that, check out the `graphsense-setup` project.** Alternatively, you can set up each required service manually, in which case, keep on reading.
+
+### Configure
+Create a new configuration by copying the `env.example` file to `.env`.
+Modify the configuration match your environment, or keep everything intact.
+
+Make sure that: 
+ - `CASSANDRA_HOST` points to an existing cassandra instance;
+ - `BUCKET_SIZE` matches one set in the `.env` file of transformation pipeline.
+
+Run `docker/gen_secret_key.sh` to fill in the `FLASK_KEY` parameter in your `.env`.
+
+Apply the configuation by adding this line to `docker-compose.yml`:
+```yaml
+services:
+    graphsense-rest:
+        ...
+        env_file: .env
+        ...
+```
+
+### Build 
+`docker-compose build`
+
+### Run
+`docker-compose up -d`
+
+The REST API will be reachable at `0.0.0.0:$REST_PORT`; $REST_PORT is set in `.env` file.
+
+
 ## Prerequisites
 
 Make sure you are running Python version >= 3.7

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ services:
 
 The REST API will be reachable at `0.0.0.0:$REST_PORT`; $REST_PORT is set in `.env` file.
 
+Make sure to initialize the local SQlite user database by running `./docker/init_db.sh`. 
+
 
 ## Prerequisites
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2"
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
         NUM_WORKERS: "${NUM_WORKERS}"
     ports:
       - "$REST_PORT:9000"
-    environment:
-      SECRET_KEY: "${SECRET_KEY}"
     restart: always
     networks:
      - graphsense-global-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,12 @@ services:
       args:
         NUM_WORKERS: "${NUM_WORKERS}"
     ports:
-      - 127.0.0.1:9000:9000
+      - "$REST_PORT:9000"
     environment:
       SECRET_KEY: "${SECRET_KEY}"
     restart: always
+    networks:
+     - graphsense-global-net
+networks:
+  graphsense-global-net:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       args:
         NUM_WORKERS: "${NUM_WORKERS}"
     volumes:
-     - "./data:/usr/var/data/"
+     - "$PWD/rest_data:/usr/var/data/"
     ports:
       - "$REST_PORT:9000"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       dockerfile: ./Dockerfile
       args:
         NUM_WORKERS: "${NUM_WORKERS}"
+    volumes:
+     - "./data:/usr/var/data/"
     ports:
       - "$REST_PORT:9000"
     restart: always

--- a/docker/env.template
+++ b/docker/env.template
@@ -1,4 +1,0 @@
-# number of gunicorn worker processes
-NUM_WORKERS=3
-# Flask secret key
-SECRET_KEY=FLASK_SECRET_KEY

--- a/docker/init_db.sh
+++ b/docker/init_db.sh
@@ -1,0 +1,1 @@
+docker exec graphsense-rest flask init-db

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # number of gunicorn worker processes
 NUM_WORKERS=3
-# Flask secret key
+# Flask secret key. Use ./docker/gen_secret_key.sh to fill this field in.
 SECRET_KEY=FLASK_SECRET_KEY
 
 # TCP port where the rest service is going to be listening.
@@ -25,5 +25,3 @@ TARGET_KEYSPACE=btc_transformed
 
 # Keyspace containing tag information
 TAG_KEYSPACE=tagpacks
-
-

--- a/env.example
+++ b/env.example
@@ -1,0 +1,29 @@
+# number of gunicorn worker processes
+NUM_WORKERS=3
+# Flask secret key
+SECRET_KEY=FLASK_SECRET_KEY
+
+# TCP port where the rest service is going to be listening.
+REST_PORT=9000
+
+# How many days should pass before a login session expires
+REST_ACCESS_TOKEN_EXPIRES_DAYS=1
+
+
+# Host where a cassandra instance can be found
+CASSANDRA_HOST=cassandra
+
+BUCKET_SIZE=25000
+
+# Cassandra keyspaces:
+
+# Raw cassandra keyspace - exporter will put raw blockchain data here. REST will read some basic information from here.
+RAW_KEYSPACE=btc_raw
+
+# Keyspace that contains transformed data (i.e. all data that is read by the REST service)
+TARGET_KEYSPACE=btc_transformed
+
+# Keyspace containing tag information
+TAG_KEYSPACE=tagpacks
+
+

--- a/env.example
+++ b/env.example
@@ -12,6 +12,7 @@ REST_ACCESS_TOKEN_EXPIRES_DAYS=1
 
 # Host where a cassandra instance can be found
 CASSANDRA_HOST=cassandra
+CASSANDRA_PORT=9042
 
 BUCKET_SIZE=25000
 

--- a/gsrest/config.py
+++ b/gsrest/config.py
@@ -13,7 +13,7 @@ class Config:
     USER_DB_FILE = 'users.sqlite'
     SECRET_KEY = os.getenv('SECRET_KEY', 'my_precious_secret_key')
     DEBUG = False
-    JWT_ACCESS_TOKEN_EXPIRES_DAYS = 1
+    JWT_ACCESS_TOKEN_EXPIRES_DAYS = os.getenv('REST_ACCESS_TOKEN_EXPIRES_DAYS', 1)
     USE_PROXY = False
 
     def __init__(self, instance_path):

--- a/gsrest/config.py
+++ b/gsrest/config.py
@@ -21,4 +21,4 @@ class Config:
 
     @property
     def DATABASE(self):
-        return os.path.join(self.instance_path, self.USER_DB_FILE)
+        return os.path.join("/usr/var/data/", self.USER_DB_FILE)

--- a/gsrest/config.py
+++ b/gsrest/config.py
@@ -13,7 +13,7 @@ class Config:
     USER_DB_FILE = 'users.sqlite'
     SECRET_KEY = os.getenv('SECRET_KEY', 'my_precious_secret_key')
     DEBUG = False
-    JWT_ACCESS_TOKEN_EXPIRES_DAYS = os.getenv('REST_ACCESS_TOKEN_EXPIRES_DAYS', 1)
+    JWT_ACCESS_TOKEN_EXPIRES_DAYS = int(os.getenv('REST_ACCESS_TOKEN_EXPIRES_DAYS', "1"))
     USE_PROXY = False
 
     def __init__(self, instance_path):

--- a/gsrest/db/cassandra.py
+++ b/gsrest/db/cassandra.py
@@ -1,6 +1,6 @@
 from cassandra.cluster import Cluster
 from cassandra.query import named_tuple_factory
-
+import os
 from flask import current_app, g, abort
 
 from gsrest.util.exceptions import MissingConfigError
@@ -13,7 +13,9 @@ def init_app(app):
 def get_cluster():
     if 'ccluster' not in g:
         current_app.logger.info("Opening new Cassandra cluster connection.")
-        g.ccluster = Cluster(current_app.config["CASSANDRA_NODES"])
+        host = os.environ['CASSANDRA_HOST']
+        port = os.environ['CASSANDRA_PORT']
+        g.ccluster = Cluster([(host, port)])
 
     return g.ccluster
 

--- a/gsrest/service/entities_service.py
+++ b/gsrest/service/entities_service.py
@@ -11,7 +11,7 @@ from gsrest.service.common_service import get_address_by_id_group, \
 from gsrest.service.rates_service import get_rates
 import os
 
-BUCKET_SIZE = os.getenv("BUCKET_SIZE")
+BUCKET_SIZE = int(os.getenv("BUCKET_SIZE"))
 ENTITY_PAGE_SIZE = 100
 ENTITY_ADDRESSES_PAGE_SIZE = 100
 

--- a/gsrest/service/entities_service.py
+++ b/gsrest/service/entities_service.py
@@ -9,8 +9,9 @@ from gsrest.model.tags import Tag
 from gsrest.service.common_service import get_address_by_id_group, \
     get_address_with_tags
 from gsrest.service.rates_service import get_rates
+import os
 
-BUCKET_SIZE = 25000  # TODO: get BUCKET_SIZE from cassandra
+BUCKET_SIZE = os.getenv("BUCKET_SIZE")
 ENTITY_PAGE_SIZE = 100
 ENTITY_ADDRESSES_PAGE_SIZE = 100
 

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,0 +1,22 @@
+# This file contains instance specific configuration options.
+
+# Cassandra host names and keyspace names are taken from the .env file. Consult README for more infromation.
+
+import os
+CASSANDRA_NODES = [os.getenv("CASSANDRA_HOST")]
+
+MAPPING = {
+    "tagpacks": os.getenv("TAG_KEYSPACE"),
+    "btc": [os.getenv("RAW_KEYSPACE"), os.getenv("TARGET_KEYSPACE")]
+}
+
+#USE_PROXY = True
+
+# Restrict allowed origins for CORS
+#
+# The origin, or list of origins to allow requests from. The origin(s) may be regular expressions, case-sensitive strings, or else an asterisk
+# (see https://flask-cors.readthedocs.io/en/latest/api.html for further details)
+#
+# Default : ‘*’ 
+# ALLOWED_ORIGINS = ['https://example.com']
+


### PR DESCRIPTION
Makes the project configurable using .env files and runnable both individually and through the graphsense-setup project.
See commit messages and README for more information.
If you notice anything that is unclear or can be improved don't hesitate to mention that.